### PR TITLE
Clears hilited_digit style on delete.

### DIFF
--- a/sudoker.js
+++ b/sudoker.js
@@ -72,6 +72,7 @@ function handle_key(event) {
 		case "\b": 	// Backspace
 			if (!winTime && !selectedCell.getAttribute("given"))
 				selectedCell.textContent = "";
+				selectedCell.removeAttribute("hilited_digit");
 			handled = true;
 			break;
 		case "\r":  	// Enter


### PR DESCRIPTION
When deleting the current cell, it doesn't clear the digit highlight (if there is one).
https://github.com/user-attachments/assets/4753904b-072f-4df1-b458-c6a3b311d3fe
